### PR TITLE
Initial UseIncludeBuilder Implementation

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,0 +1,44 @@
+name: Build-CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    paths:
+      - "."
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        dotnet-version: ["5.0.x"]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Setup dotnet ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Build solution
+        run: dotnet build
+      - name: Test solution
+        run: dotnet test
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: ./EFCore.IncludeBuilder/bin
+      - name: Benchmark
+        run: dotnet run --project EFCore.IncludeBuilder.Benchmarks -c Release
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmarks
+          path: ./BenchmarkDotNet.Artifacts/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": "Benchmark",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build release",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/EFCore.IncludeBuilder.Benchmarks/bin/Release/net5.0/EfCore.IncludeBuilder.Benchmarks.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/EFCore.IncludeBuilder.Benchmarks",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/EFCore.IncludeBuilder.Benchmarks/EFCore.IncludeBuilder.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "build release",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+          "build",
+          "${workspaceFolder}/EFCore.IncludeBuilder.Benchmarks/EFCore.IncludeBuilder.Benchmarks.csproj",
+          "-c",
+          "Release"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/EFCore.IncludeBuilder.Benchmarks/EFCore.IncludeBuilder.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "${workspaceFolder}/EFCore.IncludeBuilder.Benchmarks/EFCore.IncludeBuilder.Benchmarks.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/EFCore.IncludeBuilder.Tests.Common/EFCore.IncludeBuilder.Tests.Common.csproj
+++ b/EFCore.IncludeBuilder.Tests.Common/EFCore.IncludeBuilder.Tests.Common.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net5.0</TargetFramework>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
+	</ItemGroup>
+</Project>

--- a/EFCore.IncludeBuilder.Tests.Common/Models/Blog.cs
+++ b/EFCore.IncludeBuilder.Tests.Common/Models/Blog.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EFCore.IncludeBuilder.Tests.Common.Models
+{
+    public class Blog
+    {
+        public Guid Id { get; set; }
+        public IEnumerable<Post> Posts { get; set; } = new List<Post>();
+        public Guid AuthorId { get; set; }
+        public User Author { get; set; } = null!;
+        public IEnumerable<User> Followers { get; set; } = new List<User>();
+    }
+}

--- a/EFCore.IncludeBuilder.Tests.Common/Models/Post.cs
+++ b/EFCore.IncludeBuilder.Tests.Common/Models/Post.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EFCore.IncludeBuilder.Tests.Common.Models
+{
+    public class Post
+    {
+        public Guid Id { get; set; }
+        public Guid BlogId { get; set; }
+        public Blog Blog { get; set; } = null!;
+        public Guid AuthorId { get; set; }
+        public User Author { get; set; } = null!;
+        public IEnumerable<User> Readers { get; set; } = new List<User>();
+        public DateTime PostDate { get; set; }
+    }
+}

--- a/EFCore.IncludeBuilder.Tests.Common/Models/User.cs
+++ b/EFCore.IncludeBuilder.Tests.Common/Models/User.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EFCore.IncludeBuilder.Tests.Common.Models
+{
+    public class User
+    {
+        public Guid Id { get; set; }
+
+        public IEnumerable<Blog> FollowingBlogs { get; set; } = new List<Blog>();
+        public IEnumerable<Post> ReadHistory { get; set; } = new List<Post>();
+        public Blog OwnedBlog { get; set; } = null!;
+        public IEnumerable<Post> Posts { get; set; } = new List<Post>();
+    }
+}

--- a/EFCore.IncludeBuilder.Tests.Common/TestDbContext.cs
+++ b/EFCore.IncludeBuilder.Tests.Common/TestDbContext.cs
@@ -1,0 +1,57 @@
+﻿using EFCore.IncludeBuilder.Tests.Common.Models;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System.Data.Common;
+
+namespace EFCore.IncludeBuilder.Tests.Common
+{
+    public class TestDbContext : DbContext
+    {
+        public TestDbContext() : base(
+            new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlite(CreateInMemoryDatabase())
+                .Options)
+        { }
+
+        public DbSet<User> Users => Set<User>();
+        public DbSet<Blog> Blogs => Set<Blog>();
+        public DbSet<Post> Posts => Set<Post>();
+
+        private static DbConnection CreateInMemoryDatabase()
+        {
+            var connection = new SqliteConnection("Filename=:memory:");
+            connection.Open();
+
+            return connection;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<User>(builder =>
+            {
+                builder
+                    .HasMany(u => u.Posts)
+                    .WithOne(p => p.Author);
+
+                builder
+                    .HasOne(u => u.OwnedBlog)
+                    .WithOne(b => b.Author);
+
+                builder
+                    .HasMany(u => u.FollowingBlogs)
+                    .WithMany(b => b.Followers);
+
+                builder
+                    .HasMany(u => u.ReadHistory)
+                    .WithMany(p => p.Readers);
+            });
+
+            modelBuilder.Entity<Blog>(builder =>
+            {
+                builder
+                    .HasMany(b => b.Posts)
+                    .WithOne(p => p.Blog);
+            });
+        }
+    }
+}

--- a/EFCore.IncludeBuilder.Tests/EFCore.IncludeBuilder.Tests.csproj
+++ b/EFCore.IncludeBuilder.Tests/EFCore.IncludeBuilder.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net5.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EFCore.IncludeBuilder.Tests.Common\EFCore.IncludeBuilder.Tests.Common.csproj" />
+		<ProjectReference Include="..\EFCore.IncludeBuilder\EFCore.IncludeBuilder.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/EFCore.IncludeBuilder.Tests/FilteredUseIncludeBuilderTests.cs
+++ b/EFCore.IncludeBuilder.Tests/FilteredUseIncludeBuilderTests.cs
@@ -1,0 +1,250 @@
+using EFCore.IncludeBuilder.Extensions;
+using EFCore.IncludeBuilder.Tests;
+using EFCore.IncludeBuilder.Tests.Common;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace EFCore.IncludeBuilder.Tests
+{
+    public class FilteredUseIncludeBuilderTests : IDisposable
+    {
+        public TestDbContext testDbContext;
+
+        public FilteredUseIncludeBuilderTests()
+        {
+            testDbContext = new TestDbContext();
+        }
+
+        public void Dispose()
+        {
+            testDbContext.Dispose();
+        }
+
+        [Fact]
+        public void SingleRootIncludeFilter_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentRootIncludeFilter_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.Posts)
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+
+        [Fact]
+        public void TwoFilteredRootIncludes_ShouldMatchExpected()
+        {
+            var authorId = Guid.NewGuid();
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void TwoFilteredMixedIncludes_ShouldMatchExpected()
+        {
+            var authorId = Guid.NewGuid();
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Build()
+                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void SingleFilteredFirstLevelIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentFilteredFirstLevelIncludes_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts)
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+
+        [Fact]
+        public void MultipleFilteredFirstLevelIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .Include(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void FilteredMultiLevelIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                        .Include(p => p.Readers, builder => builder
+                            .Include(r => r.ReadHistory)
+                            .Include(r => r.Posts)
+                        )
+                        .Include(p => p.Author)
+                    )
+                    .Include(b => b.Followers, builder => builder
+                        .Include(f => f.OwnedBlog)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.ReadHistory)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Author)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void FilteredExtensionIncludes_ShouldMatchExpected()
+        {
+            var authorId = Guid.NewGuid();
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .IncludeBlogChildren(u => u.OwnedBlog)
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Followers, builder => builder
+                        .IncludeBlogChildren(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                            .ThenInclude(b => b.Posts)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentFilteredExtensionIncludes_ShouldNotMatch()
+        {
+            var authorId = Guid.NewGuid();
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .IncludeBlogChildren(u => u.OwnedBlog)
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Followers, builder => builder
+                        .IncludeBlogChildren(f => f.FollowingBlogs)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                            .ThenInclude(b => b.Posts)
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+    }
+}

--- a/EFCore.IncludeBuilder.Tests/SimpleUseIncludeBuilderTests.cs
+++ b/EFCore.IncludeBuilder.Tests/SimpleUseIncludeBuilderTests.cs
@@ -1,0 +1,317 @@
+using EFCore.IncludeBuilder.Extensions;
+using EFCore.IncludeBuilder.Tests;
+using EFCore.IncludeBuilder.Tests.Common;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using System;
+using Xunit;
+
+namespace EFCore.IncludeBuilder.Tests
+{
+    public class SimpleUseIncludeBuilderTests : IDisposable
+    {
+        public TestDbContext testDbContext;
+
+        public SimpleUseIncludeBuilderTests()
+        {
+            testDbContext = new TestDbContext();
+        }
+
+        public void Dispose()
+        {
+            testDbContext.Dispose();
+        }
+
+        [Fact]
+        public void NoIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void SingleRootInclude_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog)
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentRootIncludes_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog)
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+
+        [Fact]
+        public void TwoRootIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog)
+                .Include(u => u.FollowingBlogs)
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                .Include(u => u.FollowingBlogs)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void TwoMixedIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog)
+                .Build()
+                .Include(u => u.FollowingBlogs)
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                .Include(u => u.FollowingBlogs)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentMixedIncludes_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Build()
+                .Include(u => u.FollowingBlogs)
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                .Include(u => u.FollowingBlogs)
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+
+        [Fact]
+        public void SingleFirstLevelIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts)
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void MultipleFirstLevelIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts)
+                    .Include(b => b.Followers)
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentFirstLevelIncludes_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts)
+                    .Include(b => b.Followers)
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(u => u.Author)
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+
+        [Fact]
+        public void MultiLevelIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts, builder => builder
+                        .Include(p => p.Readers, builder => builder
+                            .Include(r => r.ReadHistory)
+                            .Include(r => r.Posts)
+                        )
+                        .Include(p => p.Author)
+                    )
+                    .Include(b => b.Followers, builder => builder
+                        .Include(f => f.OwnedBlog)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.ReadHistory)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Author)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentMultiLevelIncludes_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts, builder => builder
+                        .Include(p => p.Readers, builder => builder
+                            .Include(r => r.Posts)
+                        )
+                        .Include(p => p.Author)
+                    )
+                    .Include(b => b.Followers, builder => builder
+                        .Include(f => f.OwnedBlog)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.ReadHistory)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Author)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+
+        [Fact]
+        public void ExtensionIncludes_ShouldMatchExpected()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .IncludeBlogChildren(u => u.OwnedBlog)
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Followers, builder => builder
+                        .IncludeBlogChildren(f => f.OwnedBlog)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                            .ThenInclude(b => b.Posts)
+                .ToQueryString();
+
+            actualQuery.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void DifferentExtensionIncludes_ShouldNotMatch()
+        {
+            var actualQuery = testDbContext.Users
+                .UseIncludeBuilder()
+                .IncludeBlogChildren(u => u.OwnedBlog)
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Followers, builder => builder
+                        .Include(f => f.OwnedBlog)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+
+            var expectedQuery = testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                            .ThenInclude(b => b.Posts)
+                .ToQueryString();
+
+            actualQuery.Should().NotBe(expectedQuery);
+        }
+    }
+}

--- a/EFCore.IncludeBuilder.Tests/TestIncludableBuilderExtensions.cs
+++ b/EFCore.IncludeBuilder.Tests/TestIncludableBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿using EFCore.IncludeBuilder.Builders.Interfaces;
+using EFCore.IncludeBuilder.Tests.Common.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Tests
+{
+    public static class TestIncludableBuilderExtensions
+    {
+        public static TReturn IncludeBlogChildren<TBase, T, TReturn>(this IBaseIncludeBuilder<TBase, T, TReturn> baseBuilder, Expression<Func<T, Blog>> property)
+            where TBase : class
+        {
+            return baseBuilder.Include(property, builder => builder
+                .Include(b => b.Posts)
+            );
+        }
+
+        public static TReturn IncludeBlogChildren<TBase, T, TReturn>(this IBaseIncludeBuilder<TBase, T, TReturn> baseBuilder, Expression<Func<T, IEnumerable<Blog>>> property)
+            where TBase : class
+        {
+            return baseBuilder.Include(property, builder => builder
+                .Include(b => b.Posts)
+            );
+        }
+    }
+}

--- a/EFCore.IncludeBuilder.sln
+++ b/EFCore.IncludeBuilder.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.IncludeBuilder", "EFCore.IncludeBuilder\EFCore.IncludeBuilder.csproj", "{237276EA-D3D4-4A04-963D-A39A1B286617}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.IncludeBuilder.Tests", "EFCore.IncludeBuilder.Tests\EFCore.IncludeBuilder.Tests.csproj", "{1F37DC5F-F6A0-46B5-9E37-2F024268E6C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EfCore.IncludeBuilder.Benchmarks", "EfCore.IncludeBuilder.Benchmarks\EfCore.IncludeBuilder.Benchmarks.csproj", "{830969C0-5104-40FF-873E-E88FBE96C8DF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.IncludeBuilder.Tests.Common", "EFCore.IncludeBuilder.Tests.Common\EFCore.IncludeBuilder.Tests.Common.csproj", "{D2A114BD-7217-415A-B71B-D29728EAEA5B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{237276EA-D3D4-4A04-963D-A39A1B286617}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{237276EA-D3D4-4A04-963D-A39A1B286617}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{237276EA-D3D4-4A04-963D-A39A1B286617}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{237276EA-D3D4-4A04-963D-A39A1B286617}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F37DC5F-F6A0-46B5-9E37-2F024268E6C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F37DC5F-F6A0-46B5-9E37-2F024268E6C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F37DC5F-F6A0-46B5-9E37-2F024268E6C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F37DC5F-F6A0-46B5-9E37-2F024268E6C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{830969C0-5104-40FF-873E-E88FBE96C8DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{830969C0-5104-40FF-873E-E88FBE96C8DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{830969C0-5104-40FF-873E-E88FBE96C8DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{830969C0-5104-40FF-873E-E88FBE96C8DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2A114BD-7217-415A-B71B-D29728EAEA5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2A114BD-7217-415A-B71B-D29728EAEA5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2A114BD-7217-415A-B71B-D29728EAEA5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2A114BD-7217-415A-B71B-D29728EAEA5B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {18927A07-C010-44E9-B70C-F8E6F28ACE46}
+	EndGlobalSection
+EndGlobal

--- a/EFCore.IncludeBuilder/Appliers/BaseIncludeApplier.cs
+++ b/EFCore.IncludeBuilder/Appliers/BaseIncludeApplier.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore.Query;
+using System.Linq;
+
+namespace EFCore.IncludeBuilder.Appliers
+{
+    internal abstract class BaseIncludeApplier<TBase, TEntity, TProperty> where TBase : class
+    {
+        internal abstract IQueryable<TBase> Apply(IQueryable<TBase> queryable);
+    }
+}

--- a/EFCore.IncludeBuilder/Appliers/IncludeApplier.cs
+++ b/EFCore.IncludeBuilder/Appliers/IncludeApplier.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Appliers
+{
+    internal class IncludeApplier<TBase, TProperty> : BaseIncludeApplier<TBase, TBase, TProperty> where TBase : class
+    {
+        private readonly Expression<Func<TBase, TProperty>> navigationPropertyPath;
+
+        internal IncludeApplier(Expression<Func<TBase, TProperty>> navigationPropertyPath)
+        {
+            this.navigationPropertyPath = navigationPropertyPath;
+        }
+
+        internal override IQueryable<TBase> Apply(IQueryable<TBase> queryable)
+        {
+            return queryable.Include(navigationPropertyPath);
+        }
+    }
+}

--- a/EFCore.IncludeBuilder/Appliers/ThenIncludeApplier.cs
+++ b/EFCore.IncludeBuilder/Appliers/ThenIncludeApplier.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Appliers
+{
+    internal class ThenIncludeApplier<TBase, TEntity, TProperty> : BaseIncludeApplier<TBase, TEntity, TProperty> where TBase : class
+    {
+        private readonly Expression<Func<TEntity, TProperty>> navigationPropertyPath;
+
+        internal ThenIncludeApplier(Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+        {
+            this.navigationPropertyPath = navigationPropertyPath;
+        }
+
+        internal override IQueryable<TBase> Apply(IQueryable<TBase> queryable)
+        {
+            if (queryable is IIncludableQueryable<TBase, IEnumerable<TEntity>> enumerableIncludableQueryable)
+            {
+                return enumerableIncludableQueryable.ThenInclude(navigationPropertyPath);
+            }
+            else if (queryable is IIncludableQueryable<TBase, TEntity> includableQueryable)
+            {
+                return includableQueryable.ThenInclude(navigationPropertyPath);
+            }
+
+            throw new Exception("Unsupported Includable Query.");
+        }
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/BaseIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/BaseIncludeBuilder.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace EFCore.IncludeBuilder.Builders
+{
+    internal abstract class BaseIncludeBuilder<TBase> where TBase : class
+    {
+        internal List<BaseIncludeBuilder<TBase>> IncludableBuilders { get; } = new();
+
+        internal BaseIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder)
+        {
+            ParentBuilder = parentBuilder;
+        }
+
+        internal BaseIncludeBuilder<TBase> ParentBuilder { get; }
+
+        internal abstract IQueryable<TBase> Apply(IQueryable<TBase> query);
+
+        internal IEnumerable<BaseIncludeBuilder<TBase>> GetLeafNodes()
+        {
+            if (IncludableBuilders.Any())
+                return IncludableBuilders.SelectMany(i => i.GetLeafNodes());
+
+            return new List<BaseIncludeBuilder<TBase>> { this };
+        }
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/EnumerableThenIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/EnumerableThenIncludeBuilder.cs
@@ -1,0 +1,47 @@
+﻿using EFCore.IncludeBuilder.Appliers;
+using EFCore.IncludeBuilder.Builders.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Builders
+{
+    internal class EnumerableThenIncludeBuilder<TBase, TPreviousEntity, TEntity> : BaseIncludeBuilder<TBase>, IIncludeBuilder<TBase, TEntity> where TBase : class
+    {
+        private readonly BaseIncludeApplier<TBase, TPreviousEntity, IEnumerable<TEntity>> includeApplier;
+
+        internal EnumerableThenIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder, BaseIncludeApplier<TBase, TPreviousEntity, IEnumerable<TEntity>> includeApplier) : base(parentBuilder)
+        {
+            this.includeApplier = includeApplier;
+        }
+
+        public IIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+            Expression<Func<TEntity, TNextProperty>> navigationPropertyPath,
+            Action<IIncludeBuilder<TBase, TNextProperty>> builder = null)
+        {
+            var includeApplier = new ThenIncludeApplier<TBase, TEntity, TNextProperty>(navigationPropertyPath);
+            var childBuilder = new ThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+            builder?.Invoke(childBuilder);
+
+            IncludableBuilders.Add(childBuilder);
+
+            return this;
+        }
+
+        public IIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+            Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath,
+            Action<IIncludeBuilder<TBase, TNextProperty>> builder = null)
+        {
+            var includeApplier = new ThenIncludeApplier<TBase, TEntity, IEnumerable<TNextProperty>>(navigationPropertyPath);
+            var childBuilder = new EnumerableThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+            builder?.Invoke(childBuilder);
+
+            IncludableBuilders.Add(childBuilder);
+
+            return this;
+        }
+
+        internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => includeApplier.Apply(query);
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/Interfaces/IBaseIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/Interfaces/IBaseIncludeBuilder.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Builders.Interfaces
+{
+    public interface IBaseIncludeBuilder<TBase, TEntity, TReturn>
+        where TBase : class
+    {
+        TReturn Include<TNextProperty>(Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath, Action<IIncludeBuilder<TBase, TNextProperty>> builder = null);
+        TReturn Include<TNextProperty>(Expression<Func<TEntity, TNextProperty>> navigationPropertyPath, Action<IIncludeBuilder<TBase, TNextProperty>> builder = null);
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace EFCore.IncludeBuilder.Builders.Interfaces
+{
+    public interface IIncludeBuilder<TBase, TEntity> : IBaseIncludeBuilder<TBase, TEntity, IIncludeBuilder<TBase, TEntity>> where TBase : class
+    {
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeQueryBuildable.cs
+++ b/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeQueryBuildable.cs
@@ -1,0 +1,9 @@
+﻿using System.Linq;
+
+namespace EFCore.IncludeBuilder.Builders.Interfaces
+{
+    public interface IIncludeQueryBuildable<TBase> where TBase : class
+    {
+        IQueryable<TBase> Build();
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/Interfaces/IRootIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/Interfaces/IRootIncludeBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace EFCore.IncludeBuilder.Builders.Interfaces
+{
+    public interface IRootIncludeBuilder<TBase> : IIncludeQueryBuildable<TBase>, IBaseIncludeBuilder<TBase, TBase, IRootIncludeBuilder<TBase>> where TBase : class
+    {
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/RootIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/RootIncludeBuilder.cs
@@ -1,0 +1,76 @@
+﻿using EFCore.IncludeBuilder.Appliers;
+using EFCore.IncludeBuilder.Builders.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Builders
+{
+    internal class RootIncludeBuilder<TBase> : BaseIncludeBuilder<TBase>, IRootIncludeBuilder<TBase> where TBase : class
+    {
+        private readonly IQueryable<TBase> source;
+
+        internal RootIncludeBuilder(IQueryable<TBase> source) : base(null)
+        {
+            this.source = source;
+        }
+
+        public IRootIncludeBuilder<TBase> Include<TNextProperty>(
+            Expression<Func<TBase, TNextProperty>> navigationPropertyPath,
+            Action<IIncludeBuilder<TBase, TNextProperty>> builder = null)
+        {
+            var includeApplier = new IncludeApplier<TBase, TNextProperty>(navigationPropertyPath);
+            var childBuilder = new ThenIncludeBuilder<TBase, TBase, TNextProperty>(this, includeApplier);
+            builder?.Invoke(childBuilder);
+
+            IncludableBuilders.Add(childBuilder);
+
+            return this;
+        }
+
+        public IRootIncludeBuilder<TBase> Include<TNextProperty>(
+            Expression<Func<TBase, IEnumerable<TNextProperty>>> navigationPropertyPath,
+            Action<IIncludeBuilder<TBase, TNextProperty>> builder = null)
+        {
+            var includeApplier = new IncludeApplier<TBase, IEnumerable<TNextProperty>>(navigationPropertyPath);
+            var childBuilder = new EnumerableThenIncludeBuilder<TBase, TBase, TNextProperty>(this, includeApplier);
+            builder?.Invoke(childBuilder);
+
+            IncludableBuilders.Add(childBuilder);
+
+            return this;
+        }
+
+        public IQueryable<TBase> Build()
+        {
+            var builtSource = source;
+            foreach (var leafBuilder in GetLeafNodes())
+            {
+                var parentChain = GetParentChain(leafBuilder);
+                foreach (var node in parentChain)
+                {
+                    builtSource = node.Apply(builtSource);
+                }
+            }
+
+            return builtSource;
+        }
+
+        private static IEnumerable<BaseIncludeBuilder<TBase>> GetParentChain(BaseIncludeBuilder<TBase> node)
+        {
+            var chain = new List<BaseIncludeBuilder<TBase>>();
+            BaseIncludeBuilder<TBase> currentNode = node;
+
+            while (currentNode != null)
+            {
+                chain.Add(currentNode);
+                currentNode = currentNode.ParentBuilder;
+            }
+
+            return chain.AsEnumerable().Reverse();
+        }
+
+        internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => query;
+    }
+}

--- a/EFCore.IncludeBuilder/Builders/ThenIncludeBuilder.cs
+++ b/EFCore.IncludeBuilder/Builders/ThenIncludeBuilder.cs
@@ -1,0 +1,47 @@
+﻿using EFCore.IncludeBuilder.Appliers;
+using EFCore.IncludeBuilder.Builders.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace EFCore.IncludeBuilder.Builders
+{
+    internal class ThenIncludeBuilder<TBase, TPreviousEntity, TEntity> : BaseIncludeBuilder<TBase>, IIncludeBuilder<TBase, TEntity> where TBase : class
+    {
+        private readonly BaseIncludeApplier<TBase, TPreviousEntity, TEntity> parentApplier;
+
+        internal ThenIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder, BaseIncludeApplier<TBase, TPreviousEntity, TEntity> applier) : base(parentBuilder)
+        {
+            parentApplier = applier;
+        }
+
+        public IIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+            Expression<Func<TEntity, TNextProperty>> navigationPropertyPath,
+            Action<IIncludeBuilder<TBase, TNextProperty>> builder = null)
+        {
+            var includeApplier = new ThenIncludeApplier<TBase, TEntity, TNextProperty>(navigationPropertyPath);
+            var childBuilder = new ThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+            builder?.Invoke(childBuilder);
+
+            IncludableBuilders.Add(childBuilder);
+
+            return this;
+        }
+
+        public IIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+            Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath,
+            Action<IIncludeBuilder<TBase, TNextProperty>> builder = null)
+        {
+            var includeApplier = new ThenIncludeApplier<TBase, TEntity, IEnumerable<TNextProperty>>(navigationPropertyPath);
+            var childBuilder = new EnumerableThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+            builder?.Invoke(childBuilder);
+
+            IncludableBuilders.Add(childBuilder);
+
+            return this;
+        }
+
+        internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => parentApplier.Apply(query);
+    }
+}

--- a/EFCore.IncludeBuilder/EFCore.IncludeBuilder.csproj
+++ b/EFCore.IncludeBuilder/EFCore.IncludeBuilder.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
+	</ItemGroup>
+</Project>

--- a/EFCore.IncludeBuilder/Extensions/EntityFrameworkCoreExtensions.cs
+++ b/EFCore.IncludeBuilder/Extensions/EntityFrameworkCoreExtensions.cs
@@ -1,0 +1,14 @@
+﻿using EFCore.IncludeBuilder.Builders;
+using EFCore.IncludeBuilder.Builders.Interfaces;
+using System.Linq;
+
+namespace EFCore.IncludeBuilder.Extensions
+{
+    public static class EntityFrameworkCoreExtensions
+    {
+        public static IRootIncludeBuilder<TEntity> UseIncludeBuilder<TEntity>(this IQueryable<TEntity> source) where TEntity : class
+        {
+            return new RootIncludeBuilder<TEntity>(source);
+        }
+    }
+}

--- a/EfCore.IncludeBuilder.Benchmarks/EFCore.IncludeBuilder.Benchmarks.csproj
+++ b/EfCore.IncludeBuilder.Benchmarks/EFCore.IncludeBuilder.Benchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EFCore.IncludeBuilder.Tests.Common\EFCore.IncludeBuilder.Tests.Common.csproj" />
+    <ProjectReference Include="..\EFCore.IncludeBuilder\EFCore.IncludeBuilder.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EfCore.IncludeBuilder.Benchmarks/IncludeVsUseIncludeBuilder.cs
+++ b/EfCore.IncludeBuilder.Benchmarks/IncludeVsUseIncludeBuilder.cs
@@ -1,0 +1,52 @@
+﻿using BenchmarkDotNet.Attributes;
+using EFCore.IncludeBuilder.Extensions;
+using EFCore.IncludeBuilder.Tests.Common;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace EFCore.IncludeBuilder.Benchmarks
+{
+    public class IncludeVsUseIncludeBuilder
+    {
+        private TestDbContext testDbContext;
+
+        public IncludeVsUseIncludeBuilder()
+        {
+            testDbContext = new TestDbContext();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            testDbContext.Dispose();
+        }
+
+        [Benchmark]
+        public string Include()
+        {
+            return testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.ReadHistory)
+                .ToQueryString();
+        }
+
+        [Benchmark]
+        public string UseIncludeBuilder()
+        {
+            return testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                        .Include(p => p.Readers, builder => builder
+                            .Include(r => r.ReadHistory)
+                        )
+                    )
+                )
+                .Build()
+                .ToQueryString();
+        }
+    }
+}

--- a/EfCore.IncludeBuilder.Benchmarks/MultiIncludeVsUseIncludeBuilder.cs
+++ b/EfCore.IncludeBuilder.Benchmarks/MultiIncludeVsUseIncludeBuilder.cs
@@ -1,0 +1,88 @@
+﻿using BenchmarkDotNet.Attributes;
+using EFCore.IncludeBuilder.Extensions;
+using EFCore.IncludeBuilder.Tests.Common;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace EFCore.IncludeBuilder.Benchmarks
+{
+    public class MultiIncludeVsUseIncludeBuilder
+    {
+        private TestDbContext testDbContext;
+
+        public MultiIncludeVsUseIncludeBuilder()
+        {
+            testDbContext = new TestDbContext();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            testDbContext.Dispose();
+        }
+
+        [Benchmark]
+        public string Include()
+        {
+            return testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.ReadHistory)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts)
+                        .ThenInclude(p => p.Author)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                .ToQueryString();
+        }
+
+        [Benchmark]
+        public string Include_DuplicatedFilter()
+        {
+            return testDbContext.Users
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.ReadHistory)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Readers)
+                            .ThenInclude(p => p.Posts)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                        .ThenInclude(p => p.Author)
+                .Include(u => u.OwnedBlog)
+                    .ThenInclude(b => b.Followers)
+                        .ThenInclude(f => f.OwnedBlog)
+                .ToQueryString();
+        }
+
+        [Benchmark]
+        public string UseIncludeBuilder()
+        {
+            return testDbContext.Users
+                .UseIncludeBuilder()
+                .Include(u => u.OwnedBlog, builder => builder
+                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                        .Include(p => p.Readers, builder => builder
+                            .Include(r => r.ReadHistory)
+                            .Include(r => r.Posts)
+                        )
+                        .Include(p => p.Author)
+                    )
+                    .Include(b => b.Followers, builder => builder
+                        .Include(f => f.OwnedBlog)
+                    )
+                )
+                .Build()
+                .ToQueryString();
+        }
+    }
+}

--- a/EfCore.IncludeBuilder.Benchmarks/Program.cs
+++ b/EfCore.IncludeBuilder.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace EFCore.IncludeBuilder.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run(typeof(Program).Assembly);
+        }
+    }
+}


### PR DESCRIPTION
- Wrote initial ```UseIncludeBuilder``` implementation based on [proposal](https://github.com/dotnet/efcore/issues/23110) on dotnet/efcore repository.
- Covered ```UseIncludeBuilder``` extension with unit tests.
  -  Wrote includes using regular ```Include(...).ThenInclude(...)``` chains and ```UseIncludeBuilder()``` and then asserted on generated ```ToQueryString```.
- Added benchmarks using  ```BenchmarkDotNet```.
- Added github actions
  - Build -> Test -> Upload build -> Benchmark -> Upload Benchmark. 
