### PR TITLE
Added EditorConfig and Refactored Files Accordingly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_var_for_built_in_types=true:silent
+csharp_style_var_when_type_is_apparent=true:silent
+csharp_style_var_elsewhere=false:suggestion

--- a/EFCore.IncludeBuilder.sln
+++ b/EFCore.IncludeBuilder.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.IncludeBuilder", "src\EFCore.IncludeBuilder\EFCore.IncludeBuilder.csproj", "{237276EA-D3D4-4A04-963D-A39A1B286617}"
 EndProject
@@ -13,6 +13,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.IncludeBuilder.Tests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DB36BD08-E8A0-4299-804F-CD128D2A9075}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		tests\Directory.Build.props = tests\Directory.Build.props
 	EndProjectSection

--- a/src/EFCore.IncludeBuilder/Appliers/BaseIncludeApplier.cs
+++ b/src/EFCore.IncludeBuilder/Appliers/BaseIncludeApplier.cs
@@ -1,9 +1,8 @@
 ﻿using System.Linq;
 
-namespace EFCore.IncludeBuilder.Appliers
+namespace EFCore.IncludeBuilder.Appliers;
+
+internal abstract class BaseIncludeApplier<TBase, TEntity, TProperty> where TBase : class
 {
-    internal abstract class BaseIncludeApplier<TBase, TEntity, TProperty> where TBase : class
-    {
-        internal abstract IQueryable<TBase> Apply(IQueryable<TBase> queryable);
-    }
+    internal abstract IQueryable<TBase> Apply(IQueryable<TBase> queryable);
 }

--- a/src/EFCore.IncludeBuilder/Appliers/IncludeApplier.cs
+++ b/src/EFCore.IncludeBuilder/Appliers/IncludeApplier.cs
@@ -3,18 +3,17 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace EFCore.IncludeBuilder.Appliers
+namespace EFCore.IncludeBuilder.Appliers;
+
+internal class IncludeApplier<TBase, TProperty> : BaseIncludeApplier<TBase, TBase, TProperty> where TBase : class
 {
-    internal class IncludeApplier<TBase, TProperty> : BaseIncludeApplier<TBase, TBase, TProperty> where TBase : class
+    private readonly Expression<Func<TBase, TProperty>> navigationPropertyPath;
+
+    internal IncludeApplier(Expression<Func<TBase, TProperty>> navigationPropertyPath)
     {
-        private readonly Expression<Func<TBase, TProperty>> navigationPropertyPath;
-
-        internal IncludeApplier(Expression<Func<TBase, TProperty>> navigationPropertyPath)
-        {
-            this.navigationPropertyPath = navigationPropertyPath;
-        }
-
-        internal override IQueryable<TBase> Apply(IQueryable<TBase> queryable) =>
-            queryable.Include(navigationPropertyPath);
+        this.navigationPropertyPath = navigationPropertyPath;
     }
+
+    internal override IQueryable<TBase> Apply(IQueryable<TBase> queryable) =>
+        queryable.Include(navigationPropertyPath);
 }

--- a/src/EFCore.IncludeBuilder/Appliers/ThenIncludeApplier.cs
+++ b/src/EFCore.IncludeBuilder/Appliers/ThenIncludeApplier.cs
@@ -6,26 +6,25 @@ using System.Linq;
 using System.Linq.Expressions;
 using EFCore.IncludeBuilder.Exceptions;
 
-namespace EFCore.IncludeBuilder.Appliers
+namespace EFCore.IncludeBuilder.Appliers;
+
+internal class ThenIncludeApplier<TBase, TEntity, TProperty> : BaseIncludeApplier<TBase, TEntity, TProperty> where TBase : class
 {
-    internal class ThenIncludeApplier<TBase, TEntity, TProperty> : BaseIncludeApplier<TBase, TEntity, TProperty> where TBase : class
+    private readonly Expression<Func<TEntity, TProperty>> navigationPropertyPath;
+
+    internal ThenIncludeApplier(Expression<Func<TEntity, TProperty>> navigationPropertyPath)
     {
-        private readonly Expression<Func<TEntity, TProperty>> navigationPropertyPath;
+        this.navigationPropertyPath = navigationPropertyPath;
+    }
 
-        internal ThenIncludeApplier(Expression<Func<TEntity, TProperty>> navigationPropertyPath)
-        {
-            this.navigationPropertyPath = navigationPropertyPath;
-        }
+    internal override IQueryable<TBase> Apply(IQueryable<TBase> queryable)
+    {
+        if (queryable is IIncludableQueryable<TBase, IEnumerable<TEntity>> enumerableIncludableQueryable)
+            return enumerableIncludableQueryable.ThenInclude(navigationPropertyPath);
 
-        internal override IQueryable<TBase> Apply(IQueryable<TBase> queryable)
-        {
-            if (queryable is IIncludableQueryable<TBase, IEnumerable<TEntity>> enumerableIncludableQueryable)
-                return enumerableIncludableQueryable.ThenInclude(navigationPropertyPath);
+        else if (queryable is IIncludableQueryable<TBase, TEntity> includableQueryable)
+            return includableQueryable.ThenInclude(navigationPropertyPath);
 
-            else if (queryable is IIncludableQueryable<TBase, TEntity> includableQueryable)
-                return includableQueryable.ThenInclude(navigationPropertyPath);
-
-            throw new IncludeConversionFailedException($"Found unsupported IQueryable type that cannot have .ThenInclude applied. Found type: {queryable.GetType()}.");
-        }
+        throw new IncludeConversionFailedException($"Found unsupported IQueryable type that cannot have .ThenInclude applied. Found type: {queryable.GetType()}.");
     }
 }

--- a/src/EFCore.IncludeBuilder/Builders/BaseIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/BaseIncludeBuilder.cs
@@ -1,27 +1,26 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace EFCore.IncludeBuilder.Builders
+namespace EFCore.IncludeBuilder.Builders;
+
+internal abstract class BaseIncludeBuilder<TBase> where TBase : class
 {
-    internal abstract class BaseIncludeBuilder<TBase> where TBase : class
+    internal List<BaseIncludeBuilder<TBase>> ChildBuilders { get; } = new();
+
+    internal BaseIncludeBuilder(BaseIncludeBuilder<TBase>? parentBuilder)
     {
-        internal List<BaseIncludeBuilder<TBase>> ChildBuilders { get; } = new();
+        ParentBuilder = parentBuilder;
+    }
 
-        internal BaseIncludeBuilder(BaseIncludeBuilder<TBase>? parentBuilder)
-        {
-            ParentBuilder = parentBuilder;
-        }
+    internal BaseIncludeBuilder<TBase>? ParentBuilder { get; }
 
-        internal BaseIncludeBuilder<TBase>? ParentBuilder { get; }
+    internal abstract IQueryable<TBase> Apply(IQueryable<TBase> query);
 
-        internal abstract IQueryable<TBase> Apply(IQueryable<TBase> query);
+    internal IEnumerable<BaseIncludeBuilder<TBase>> GetLeafNodes()
+    {
+        if (ChildBuilders.Any())
+            return ChildBuilders.SelectMany(i => i.GetLeafNodes());
 
-        internal IEnumerable<BaseIncludeBuilder<TBase>> GetLeafNodes()
-        {
-            if (ChildBuilders.Any())
-                return ChildBuilders.SelectMany(i => i.GetLeafNodes());
-
-            return new List<BaseIncludeBuilder<TBase>> { this };
-        }
+        return new List<BaseIncludeBuilder<TBase>> { this };
     }
 }

--- a/src/EFCore.IncludeBuilder/Builders/EnumerableThenIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/EnumerableThenIncludeBuilder.cs
@@ -5,43 +5,42 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace EFCore.IncludeBuilder.Builders
+namespace EFCore.IncludeBuilder.Builders;
+
+internal class EnumerableThenIncludeBuilder<TBase, TPreviousEntity, TEntity> : BaseIncludeBuilder<TBase>, INestedIncludeBuilder<TBase, TEntity> where TBase : class
 {
-    internal class EnumerableThenIncludeBuilder<TBase, TPreviousEntity, TEntity> : BaseIncludeBuilder<TBase>, INestedIncludeBuilder<TBase, TEntity> where TBase : class
+    private readonly BaseIncludeApplier<TBase, TPreviousEntity, IEnumerable<TEntity>> currentLevelIncludeApplier;
+
+    internal EnumerableThenIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder, BaseIncludeApplier<TBase, TPreviousEntity, IEnumerable<TEntity>> applier) : base(parentBuilder)
     {
-        private readonly BaseIncludeApplier<TBase, TPreviousEntity, IEnumerable<TEntity>> currentLevelIncludeApplier;
-
-        internal EnumerableThenIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder, BaseIncludeApplier<TBase, TPreviousEntity, IEnumerable<TEntity>> applier) : base(parentBuilder)
-        {
-            currentLevelIncludeApplier = applier;
-        }
-
-        public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
-            Expression<Func<TEntity, TNextProperty>> navigationPropertyPath,
-            Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
-        {
-            var includeApplier = new ThenIncludeApplier<TBase, TEntity, TNextProperty>(navigationPropertyPath);
-            var childBuilder = new ThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
-            builder?.Invoke(childBuilder);
-
-            ChildBuilders.Add(childBuilder);
-
-            return this;
-        }
-
-        public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
-            Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath,
-            Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
-        {
-            var includeApplier = new ThenIncludeApplier<TBase, TEntity, IEnumerable<TNextProperty>>(navigationPropertyPath);
-            var childBuilder = new EnumerableThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
-            builder?.Invoke(childBuilder);
-
-            ChildBuilders.Add(childBuilder);
-
-            return this;
-        }
-
-        internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => currentLevelIncludeApplier.Apply(query);
+        currentLevelIncludeApplier = applier;
     }
+
+    public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+        Expression<Func<TEntity, TNextProperty>> navigationPropertyPath,
+        Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
+    {
+        var includeApplier = new ThenIncludeApplier<TBase, TEntity, TNextProperty>(navigationPropertyPath);
+        var childBuilder = new ThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+        builder?.Invoke(childBuilder);
+
+        ChildBuilders.Add(childBuilder);
+
+        return this;
+    }
+
+    public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+        Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath,
+        Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
+    {
+        var includeApplier = new ThenIncludeApplier<TBase, TEntity, IEnumerable<TNextProperty>>(navigationPropertyPath);
+        var childBuilder = new EnumerableThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+        builder?.Invoke(childBuilder);
+
+        ChildBuilders.Add(childBuilder);
+
+        return this;
+    }
+
+    internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => currentLevelIncludeApplier.Apply(query);
 }

--- a/src/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeBuilder.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace EFCore.IncludeBuilder.Builders.Interfaces
+namespace EFCore.IncludeBuilder.Builders.Interfaces;
+
+public interface IIncludeBuilder<TBase, TEntity, TReturn>
+    where TBase : class
+    where TReturn : IIncludeBuilder<TBase, TEntity, TReturn>
 {
-    public interface IIncludeBuilder<TBase, TEntity, TReturn>
-        where TBase : class
-        where TReturn : IIncludeBuilder<TBase, TEntity, TReturn>
-    {
-        TReturn Include<TNextProperty>(Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath, Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null);
-        TReturn Include<TNextProperty>(Expression<Func<TEntity, TNextProperty>> navigationPropertyPath, Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null);
-    }
+    TReturn Include<TNextProperty>(Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath, Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null);
+    TReturn Include<TNextProperty>(Expression<Func<TEntity, TNextProperty>> navigationPropertyPath, Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null);
 }

--- a/src/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeQueryBuildable.cs
+++ b/src/EFCore.IncludeBuilder/Builders/Interfaces/IIncludeQueryBuildable.cs
@@ -1,9 +1,8 @@
 ﻿using System.Linq;
 
-namespace EFCore.IncludeBuilder.Builders.Interfaces
+namespace EFCore.IncludeBuilder.Builders.Interfaces;
+
+public interface IIncludeQueryBuildable<TBase> where TBase : class
 {
-    public interface IIncludeQueryBuildable<TBase> where TBase : class
-    {
-        IQueryable<TBase> Build();
-    }
+    IQueryable<TBase> Build();
 }

--- a/src/EFCore.IncludeBuilder/Builders/Interfaces/INestedIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/Interfaces/INestedIncludeBuilder.cs
@@ -1,6 +1,5 @@
-﻿namespace EFCore.IncludeBuilder.Builders.Interfaces
+﻿namespace EFCore.IncludeBuilder.Builders.Interfaces;
+
+public interface INestedIncludeBuilder<TBase, TEntity> : IIncludeBuilder<TBase, TEntity, INestedIncludeBuilder<TBase, TEntity>> where TBase : class
 {
-    public interface INestedIncludeBuilder<TBase, TEntity> : IIncludeBuilder<TBase, TEntity, INestedIncludeBuilder<TBase, TEntity>> where TBase : class
-    {
-    }
 }

--- a/src/EFCore.IncludeBuilder/Builders/Interfaces/IRootIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/Interfaces/IRootIncludeBuilder.cs
@@ -1,6 +1,5 @@
-﻿namespace EFCore.IncludeBuilder.Builders.Interfaces
+﻿namespace EFCore.IncludeBuilder.Builders.Interfaces;
+
+public interface IRootIncludeBuilder<TBase> : IIncludeQueryBuildable<TBase>, IIncludeBuilder<TBase, TBase, IRootIncludeBuilder<TBase>> where TBase : class
 {
-    public interface IRootIncludeBuilder<TBase> : IIncludeQueryBuildable<TBase>, IIncludeBuilder<TBase, TBase, IRootIncludeBuilder<TBase>> where TBase : class
-    {
-    }
 }

--- a/src/EFCore.IncludeBuilder/Builders/RootIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/RootIncludeBuilder.cs
@@ -5,72 +5,71 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace EFCore.IncludeBuilder.Builders
+namespace EFCore.IncludeBuilder.Builders;
+
+internal class RootIncludeBuilder<TBase> : BaseIncludeBuilder<TBase>, IRootIncludeBuilder<TBase> where TBase : class
 {
-    internal class RootIncludeBuilder<TBase> : BaseIncludeBuilder<TBase>, IRootIncludeBuilder<TBase> where TBase : class
+    private readonly IQueryable<TBase> source;
+
+    internal RootIncludeBuilder(IQueryable<TBase> source) : base(null)
     {
-        private readonly IQueryable<TBase> source;
-
-        internal RootIncludeBuilder(IQueryable<TBase> source) : base(null)
-        {
-            this.source = source;
-        }
-
-        public IRootIncludeBuilder<TBase> Include<TNextProperty>(
-            Expression<Func<TBase, TNextProperty>> navigationPropertyPath,
-            Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
-        {
-            var includeApplier = new IncludeApplier<TBase, TNextProperty>(navigationPropertyPath);
-            var childBuilder = new ThenIncludeBuilder<TBase, TBase, TNextProperty>(this, includeApplier);
-            builder?.Invoke(childBuilder);
-
-            ChildBuilders.Add(childBuilder);
-
-            return this;
-        }
-
-        public IRootIncludeBuilder<TBase> Include<TNextProperty>(
-            Expression<Func<TBase, IEnumerable<TNextProperty>>> navigationPropertyPath,
-            Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
-        {
-            var includeApplier = new IncludeApplier<TBase, IEnumerable<TNextProperty>>(navigationPropertyPath);
-            var childBuilder = new EnumerableThenIncludeBuilder<TBase, TBase, TNextProperty>(this, includeApplier);
-            builder?.Invoke(childBuilder);
-
-            ChildBuilders.Add(childBuilder);
-
-            return this;
-        }
-
-        public IQueryable<TBase> Build()
-        {
-            var builtSource = source;
-            foreach (var leafBuilder in GetLeafNodes())
-            {
-                var parentChain = GetAncestorChain(leafBuilder);
-                foreach (var node in parentChain)
-                {
-                    builtSource = node.Apply(builtSource);
-                }
-            }
-
-            return builtSource;
-        }
-
-        private static IEnumerable<BaseIncludeBuilder<TBase>> GetAncestorChain(BaseIncludeBuilder<TBase> node)
-        {
-            var chain = new List<BaseIncludeBuilder<TBase>>();
-            BaseIncludeBuilder<TBase>? currentNode = node;
-
-            while (currentNode != null)
-            {
-                chain.Add(currentNode);
-                currentNode = currentNode.ParentBuilder;
-            }
-
-            return chain.AsEnumerable().Reverse();
-        }
-
-        internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => query;
+        this.source = source;
     }
+
+    public IRootIncludeBuilder<TBase> Include<TNextProperty>(
+        Expression<Func<TBase, TNextProperty>> navigationPropertyPath,
+        Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
+    {
+        var includeApplier = new IncludeApplier<TBase, TNextProperty>(navigationPropertyPath);
+        var childBuilder = new ThenIncludeBuilder<TBase, TBase, TNextProperty>(this, includeApplier);
+        builder?.Invoke(childBuilder);
+
+        ChildBuilders.Add(childBuilder);
+
+        return this;
+    }
+
+    public IRootIncludeBuilder<TBase> Include<TNextProperty>(
+        Expression<Func<TBase, IEnumerable<TNextProperty>>> navigationPropertyPath,
+        Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
+    {
+        var includeApplier = new IncludeApplier<TBase, IEnumerable<TNextProperty>>(navigationPropertyPath);
+        var childBuilder = new EnumerableThenIncludeBuilder<TBase, TBase, TNextProperty>(this, includeApplier);
+        builder?.Invoke(childBuilder);
+
+        ChildBuilders.Add(childBuilder);
+
+        return this;
+    }
+
+    public IQueryable<TBase> Build()
+    {
+        IQueryable<TBase> builtSource = source;
+        foreach (BaseIncludeBuilder<TBase> leafBuilder in GetLeafNodes())
+        {
+            IEnumerable<BaseIncludeBuilder<TBase>> parentChain = GetAncestorChain(leafBuilder);
+            foreach (BaseIncludeBuilder<TBase> node in parentChain)
+            {
+                builtSource = node.Apply(builtSource);
+            }
+        }
+
+        return builtSource;
+    }
+
+    private static IEnumerable<BaseIncludeBuilder<TBase>> GetAncestorChain(BaseIncludeBuilder<TBase> node)
+    {
+        var chain = new List<BaseIncludeBuilder<TBase>>();
+        BaseIncludeBuilder<TBase>? currentNode = node;
+
+        while (currentNode != null)
+        {
+            chain.Add(currentNode);
+            currentNode = currentNode.ParentBuilder;
+        }
+
+        return chain.AsEnumerable().Reverse();
+    }
+
+    internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => query;
 }

--- a/src/EFCore.IncludeBuilder/Builders/ThenIncludeBuilder.cs
+++ b/src/EFCore.IncludeBuilder/Builders/ThenIncludeBuilder.cs
@@ -5,43 +5,42 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace EFCore.IncludeBuilder.Builders
+namespace EFCore.IncludeBuilder.Builders;
+
+internal class ThenIncludeBuilder<TBase, TPreviousEntity, TEntity> : BaseIncludeBuilder<TBase>, INestedIncludeBuilder<TBase, TEntity> where TBase : class
 {
-    internal class ThenIncludeBuilder<TBase, TPreviousEntity, TEntity> : BaseIncludeBuilder<TBase>, INestedIncludeBuilder<TBase, TEntity> where TBase : class
+    private readonly BaseIncludeApplier<TBase, TPreviousEntity, TEntity> currentLevelIncludeApplier;
+
+    internal ThenIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder, BaseIncludeApplier<TBase, TPreviousEntity, TEntity> applier) : base(parentBuilder)
     {
-        private readonly BaseIncludeApplier<TBase, TPreviousEntity, TEntity> currentLevelIncludeApplier;
-
-        internal ThenIncludeBuilder(BaseIncludeBuilder<TBase> parentBuilder, BaseIncludeApplier<TBase, TPreviousEntity, TEntity> applier) : base(parentBuilder)
-        {
-            currentLevelIncludeApplier = applier;
-        }
-
-        public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
-            Expression<Func<TEntity, TNextProperty>> navigationPropertyPath,
-            Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
-        {
-            var includeApplier = new ThenIncludeApplier<TBase, TEntity, TNextProperty>(navigationPropertyPath);
-            var childBuilder = new ThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
-            builder?.Invoke(childBuilder);
-
-            ChildBuilders.Add(childBuilder);
-
-            return this;
-        }
-
-        public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
-            Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath,
-            Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
-        {
-            var includeApplier = new ThenIncludeApplier<TBase, TEntity, IEnumerable<TNextProperty>>(navigationPropertyPath);
-            var childBuilder = new EnumerableThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
-            builder?.Invoke(childBuilder);
-
-            ChildBuilders.Add(childBuilder);
-
-            return this;
-        }
-
-        internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => currentLevelIncludeApplier.Apply(query);
+        currentLevelIncludeApplier = applier;
     }
+
+    public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+        Expression<Func<TEntity, TNextProperty>> navigationPropertyPath,
+        Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
+    {
+        var includeApplier = new ThenIncludeApplier<TBase, TEntity, TNextProperty>(navigationPropertyPath);
+        var childBuilder = new ThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+        builder?.Invoke(childBuilder);
+
+        ChildBuilders.Add(childBuilder);
+
+        return this;
+    }
+
+    public INestedIncludeBuilder<TBase, TEntity> Include<TNextProperty>(
+        Expression<Func<TEntity, IEnumerable<TNextProperty>>> navigationPropertyPath,
+        Action<INestedIncludeBuilder<TBase, TNextProperty>>? builder = null)
+    {
+        var includeApplier = new ThenIncludeApplier<TBase, TEntity, IEnumerable<TNextProperty>>(navigationPropertyPath);
+        var childBuilder = new EnumerableThenIncludeBuilder<TBase, TEntity, TNextProperty>(this, includeApplier);
+        builder?.Invoke(childBuilder);
+
+        ChildBuilders.Add(childBuilder);
+
+        return this;
+    }
+
+    internal override IQueryable<TBase> Apply(IQueryable<TBase> query) => currentLevelIncludeApplier.Apply(query);
 }

--- a/src/EFCore.IncludeBuilder/Exceptions/IncludeConversionFailedException.cs
+++ b/src/EFCore.IncludeBuilder/Exceptions/IncludeConversionFailedException.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
-namespace EFCore.IncludeBuilder.Exceptions
+namespace EFCore.IncludeBuilder.Exceptions;
+
+[Serializable]
+public class IncludeConversionFailedException : Exception
 {
-    [Serializable]
-    public class IncludeConversionFailedException : Exception
+    public IncludeConversionFailedException()
     {
-        public IncludeConversionFailedException()
-        {
-        }
+    }
 
-        public IncludeConversionFailedException(string message) : base(message)
-        {
-        }
+    public IncludeConversionFailedException(string message) : base(message)
+    {
+    }
 
-        public IncludeConversionFailedException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    public IncludeConversionFailedException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 
-        protected IncludeConversionFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
+    protected IncludeConversionFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
     }
 }

--- a/src/EFCore.IncludeBuilder/Extensions/EntityFrameworkCoreExtensions.cs
+++ b/src/EFCore.IncludeBuilder/Extensions/EntityFrameworkCoreExtensions.cs
@@ -2,13 +2,12 @@
 using EFCore.IncludeBuilder.Builders.Interfaces;
 using System.Linq;
 
-namespace EFCore.IncludeBuilder.Extensions
+namespace EFCore.IncludeBuilder.Extensions;
+
+public static class EntityFrameworkCoreExtensions
 {
-    public static class EntityFrameworkCoreExtensions
+    public static IRootIncludeBuilder<TEntity> UseIncludeBuilder<TEntity>(this IQueryable<TEntity> source) where TEntity : class
     {
-        public static IRootIncludeBuilder<TEntity> UseIncludeBuilder<TEntity>(this IQueryable<TEntity> source) where TEntity : class
-        {
-            return new RootIncludeBuilder<TEntity>(source);
-        }
+        return new RootIncludeBuilder<TEntity>(source);
     }
 }

--- a/tests/EFCore.IncludeBuilder.Benchmarks/IncludeVsUseIncludeBuilder.cs
+++ b/tests/EFCore.IncludeBuilder.Benchmarks/IncludeVsUseIncludeBuilder.cs
@@ -5,49 +5,48 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
 
-namespace EFCore.IncludeBuilder.Benchmarks
+namespace EFCore.IncludeBuilder.Benchmarks;
+
+[MemoryDiagnoser]
+public class IncludeVsUseIncludeBuilder
 {
-    [MemoryDiagnoser]
-    public class IncludeVsUseIncludeBuilder
+    private readonly TestDbContext testDbContext;
+
+    public IncludeVsUseIncludeBuilder()
     {
-        private readonly TestDbContext testDbContext;
+        testDbContext = new TestDbContext();
+    }
 
-        public IncludeVsUseIncludeBuilder()
-        {
-            testDbContext = new TestDbContext();
-        }
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        testDbContext.Dispose();
+    }
 
-        [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-            testDbContext.Dispose();
-        }
+    [Benchmark(Baseline = true)]
+    public string Include()
+    {
+        return testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.ReadHistory)
+            .ToQueryString();
+    }
 
-        [Benchmark(Baseline = true)]
-        public string Include()
-        {
-            return testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.ReadHistory)
-                .ToQueryString();
-        }
-
-        [Benchmark]
-        public string UseIncludeBuilder()
-        {
-            return testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
-                        .Include(p => p.Readers, builder => builder
-                            .Include(r => r.ReadHistory)
-                        )
+    [Benchmark]
+    public string UseIncludeBuilder()
+    {
+        return testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                    .Include(p => p.Readers, builder => builder
+                        .Include(r => r.ReadHistory)
                     )
                 )
-                .Build()
-                .ToQueryString();
-        }
+            )
+            .Build()
+            .ToQueryString();
     }
 }

--- a/tests/EFCore.IncludeBuilder.Benchmarks/MultiIncludeVsUseIncludeBuilder.cs
+++ b/tests/EFCore.IncludeBuilder.Benchmarks/MultiIncludeVsUseIncludeBuilder.cs
@@ -5,85 +5,84 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
 
-namespace EFCore.IncludeBuilder.Benchmarks
+namespace EFCore.IncludeBuilder.Benchmarks;
+
+[MemoryDiagnoser]
+public class MultiIncludeVsUseIncludeBuilder
 {
-    [MemoryDiagnoser]
-    public class MultiIncludeVsUseIncludeBuilder
+    private readonly TestDbContext testDbContext;
+
+    public MultiIncludeVsUseIncludeBuilder()
     {
-        private readonly TestDbContext testDbContext;
+        testDbContext = new TestDbContext();
+    }
 
-        public MultiIncludeVsUseIncludeBuilder()
-        {
-            testDbContext = new TestDbContext();
-        }
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        testDbContext.Dispose();
+    }
 
-        [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-            testDbContext.Dispose();
-        }
+    [Benchmark(Baseline = true)]
+    public string Include()
+    {
+        return testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.ReadHistory)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Author)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.OwnedBlog)
+            .ToQueryString();
+    }
 
-        [Benchmark(Baseline = true)]
-        public string Include()
-        {
-            return testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.ReadHistory)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Author)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.OwnedBlog)
-                .ToQueryString();
-        }
+    [Benchmark]
+    public string Include_DuplicatedFilter()
+    {
+        return testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.ReadHistory)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .ThenInclude(p => p.Author)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.OwnedBlog)
+            .ToQueryString();
+    }
 
-        [Benchmark]
-        public string Include_DuplicatedFilter()
-        {
-            return testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.ReadHistory)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Author)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.OwnedBlog)
-                .ToQueryString();
-        }
-
-        [Benchmark]
-        public string UseIncludeBuilder()
-        {
-            return testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
-                        .Include(p => p.Readers, builder => builder
-                            .Include(r => r.ReadHistory)
-                            .Include(r => r.Posts)
-                        )
-                        .Include(p => p.Author)
+    [Benchmark]
+    public string UseIncludeBuilder()
+    {
+        return testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                    .Include(p => p.Readers, builder => builder
+                        .Include(r => r.ReadHistory)
+                        .Include(r => r.Posts)
                     )
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.OwnedBlog)
-                    )
+                    .Include(p => p.Author)
                 )
-                .Build()
-                .ToQueryString();
-        }
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.OwnedBlog)
+                )
+            )
+            .Build()
+            .ToQueryString();
     }
 }

--- a/tests/EFCore.IncludeBuilder.Benchmarks/Program.cs
+++ b/tests/EFCore.IncludeBuilder.Benchmarks/Program.cs
@@ -1,12 +1,11 @@
 ﻿using BenchmarkDotNet.Running;
 
-namespace EFCore.IncludeBuilder.Benchmarks
+namespace EFCore.IncludeBuilder.Benchmarks;
+
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            BenchmarkRunner.Run(typeof(Program).Assembly);
-        }
+        BenchmarkRunner.Run(typeof(Program).Assembly);
     }
 }

--- a/tests/EFCore.IncludeBuilder.Tests.Common/Models/Blog.cs
+++ b/tests/EFCore.IncludeBuilder.Tests.Common/Models/Blog.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace EFCore.IncludeBuilder.Tests.Common.Models
+namespace EFCore.IncludeBuilder.Tests.Common.Models;
+
+public class Blog
 {
-    public class Blog
-    {
-        public Guid Id { get; set; }
-        public IEnumerable<Post> Posts { get; set; } = new List<Post>();
-        public Guid AuthorId { get; set; }
-        public User Author { get; set; } = null!;
-        public IEnumerable<User> Followers { get; set; } = new List<User>();
-    }
+    public Guid Id { get; set; }
+    public IEnumerable<Post> Posts { get; set; } = new List<Post>();
+    public Guid AuthorId { get; set; }
+    public User Author { get; set; } = null!;
+    public IEnumerable<User> Followers { get; set; } = new List<User>();
 }

--- a/tests/EFCore.IncludeBuilder.Tests.Common/Models/Post.cs
+++ b/tests/EFCore.IncludeBuilder.Tests.Common/Models/Post.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace EFCore.IncludeBuilder.Tests.Common.Models
+namespace EFCore.IncludeBuilder.Tests.Common.Models;
+
+public class Post
 {
-    public class Post
-    {
-        public Guid Id { get; set; }
-        public Guid BlogId { get; set; }
-        public Blog Blog { get; set; } = null!;
-        public Guid AuthorId { get; set; }
-        public User Author { get; set; } = null!;
-        public IEnumerable<User> Readers { get; set; } = new List<User>();
-        public DateTime PostDate { get; set; }
-    }
+    public Guid Id { get; set; }
+    public Guid BlogId { get; set; }
+    public Blog Blog { get; set; } = null!;
+    public Guid AuthorId { get; set; }
+    public User Author { get; set; } = null!;
+    public IEnumerable<User> Readers { get; set; } = new List<User>();
+    public DateTime PostDate { get; set; }
 }

--- a/tests/EFCore.IncludeBuilder.Tests.Common/Models/User.cs
+++ b/tests/EFCore.IncludeBuilder.Tests.Common/Models/User.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace EFCore.IncludeBuilder.Tests.Common.Models
-{
-    public class User
-    {
-        public Guid Id { get; set; }
+namespace EFCore.IncludeBuilder.Tests.Common.Models;
 
-        public IEnumerable<Blog> FollowingBlogs { get; set; } = new List<Blog>();
-        public IEnumerable<Post> ReadHistory { get; set; } = new List<Post>();
-        public Blog OwnedBlog { get; set; } = null!;
-        public IEnumerable<Post> Posts { get; set; } = new List<Post>();
-    }
+public class User
+{
+    public Guid Id { get; set; }
+
+    public IEnumerable<Blog> FollowingBlogs { get; set; } = new List<Blog>();
+    public IEnumerable<Post> ReadHistory { get; set; } = new List<Post>();
+    public Blog OwnedBlog { get; set; } = null!;
+    public IEnumerable<Post> Posts { get; set; } = new List<Post>();
 }

--- a/tests/EFCore.IncludeBuilder.Tests/FilteredUseIncludeBuilderTests.cs
+++ b/tests/EFCore.IncludeBuilder.Tests/FilteredUseIncludeBuilderTests.cs
@@ -7,287 +7,286 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace EFCore.IncludeBuilder.Tests
+namespace EFCore.IncludeBuilder.Tests;
+
+public class FilteredUseIncludeBuilderTests : IDisposable
 {
-    public class FilteredUseIncludeBuilderTests : IDisposable
+    public TestDbContext testDbContext;
+
+    public FilteredUseIncludeBuilderTests()
     {
-        public TestDbContext testDbContext;
+        testDbContext = new TestDbContext();
+    }
 
-        public FilteredUseIncludeBuilderTests()
-        {
-            testDbContext = new TestDbContext();
-        }
+    public void Dispose()
+    {
+        testDbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
-        public void Dispose()
-        {
-            testDbContext.Dispose();
-            GC.SuppressFinalize(this);
-        }
+    [Fact]
+    public void SingleRootIncludeFilter_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void SingleRootIncludeFilter_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DifferentRootIncludeFilter_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.Posts)
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void DifferentRootIncludeFilter_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.Posts)
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .ToQueryString();
+        actualQuery.Should().NotBe(expectedQuery);
+    }
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
+    [Fact]
+    public void TwoFilteredRootIncludes_ShouldMatchExpected()
+    {
+        var authorId = Guid.NewGuid();
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void TwoFilteredRootIncludes_ShouldMatchExpected()
-        {
-            var authorId = Guid.NewGuid();
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void TwoFilteredMixedIncludes_ShouldMatchExpected()
+    {
+        var authorId = Guid.NewGuid();
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Build()
+            .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+            .ToQueryString();
 
-        [Fact]
-        public void TwoFilteredMixedIncludes_ShouldMatchExpected()
-        {
-            var authorId = Guid.NewGuid();
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Build()
-                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(u => u.FollowingBlogs.Where(b => b.AuthorId == authorId))
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void SingleFilteredFirstLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void SingleFilteredFirstLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DifferentFilteredFirstLevelIncludes_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void DifferentFilteredFirstLevelIncludes_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts)
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .ToQueryString();
+        actualQuery.Should().NotBe(expectedQuery);
+    }
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
+    [Fact]
+    public void MultipleFilteredFirstLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void MultipleFilteredFirstLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                    .Include(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void FilteredMultiLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
-                        .Include(p => p.Readers, builder => builder
-                            .Include(r => r.ReadHistory)
-                            .Include(r => r.Posts)
-                        )
-                        .Include(p => p.Author)
+    [Fact]
+    public void FilteredMultiLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                    .Include(p => p.Readers, builder => builder
+                        .Include(r => r.ReadHistory)
+                        .Include(r => r.Posts)
                     )
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.OwnedBlog)
-                    )
+                    .Include(p => p.Author)
                 )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.ReadHistory)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                        .ThenInclude(p => p.Author)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.OwnedBlog)
-                .ToQueryString();
-
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void FilteredExtensionIncludes_ShouldMatchExpected()
-        {
-            var authorId = Guid.NewGuid();
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .IncludeBlogChildren()
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId), builder => builder
-                            .IncludeBlogChildren()
-                        )
-                    )
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.OwnedBlog)
                 )
-                .Build()
-                .ToQueryString();
+            )
+            .Build()
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
-                            .ThenInclude(b => b.Posts)
-                .ToQueryString();
-
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void DifferentFilteredExtensionIncludes_ShouldNotMatch()
-        {
-            var authorId = Guid.NewGuid();
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .IncludeBlogChildren()
-                    .Include(b => b.Followers, builder => builder
-                        .Include(u => u.FollowingBlogs, builder => builder
-                            .IncludeBlogChildren()
-                        )
-                    )
-                )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
-                            .ThenInclude(b => b.Posts)
-                .ToQueryString();
-
-            actualQuery.Should().NotBe(expectedQuery);
-        }
-
-        [Fact]
-        public void FilteredIncludeChain_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
-                    .Include(p => p.Readers)
-                )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
                     .ThenInclude(p => p.Readers)
-                .ToQueryString();
-
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void FilteredDifferentIncludeChain_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
-                    .Include(p => p.Readers)
-                )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog.Posts)
+                        .ThenInclude(p => p.ReadHistory)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
                     .ThenInclude(p => p.Readers)
-                .ToQueryString();
+                        .ThenInclude(p => p.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                    .ThenInclude(p => p.Author)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.OwnedBlog)
+            .ToQueryString();
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
+        actualQuery.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public void FilteredExtensionIncludes_ShouldMatchExpected()
+    {
+        var authorId = Guid.NewGuid();
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .IncludeBlogChildren()
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId), builder => builder
+                        .IncludeBlogChildren()
+                    )
+                )
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                        .ThenInclude(b => b.Posts)
+            .ToQueryString();
+
+        actualQuery.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public void DifferentFilteredExtensionIncludes_ShouldNotMatch()
+    {
+        var authorId = Guid.NewGuid();
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .IncludeBlogChildren()
+                .Include(b => b.Followers, builder => builder
+                    .Include(u => u.FollowingBlogs, builder => builder
+                        .IncludeBlogChildren()
+                    )
+                )
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.FollowingBlogs.Where(b => b.AuthorId == authorId))
+                        .ThenInclude(b => b.Posts)
+            .ToQueryString();
+
+        actualQuery.Should().NotBe(expectedQuery);
+    }
+
+    [Fact]
+    public void FilteredIncludeChain_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                .Include(p => p.Readers)
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .ThenInclude(p => p.Readers)
+            .ToQueryString();
+
+        actualQuery.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public void FilteredDifferentIncludeChain_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)), builder => builder
+                .Include(p => p.Readers)
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog.Posts)
+                .ThenInclude(p => p.Readers)
+            .ToQueryString();
+
+        actualQuery.Should().NotBe(expectedQuery);
     }
 }

--- a/tests/EFCore.IncludeBuilder.Tests/SimpleUseIncludeBuilderTests.cs
+++ b/tests/EFCore.IncludeBuilder.Tests/SimpleUseIncludeBuilderTests.cs
@@ -9,382 +9,381 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace EFCore.IncludeBuilder.Tests
+namespace EFCore.IncludeBuilder.Tests;
+
+public class SimpleUseIncludeBuilderTests : IDisposable
 {
-    public class SimpleUseIncludeBuilderTests : IDisposable
+    public TestDbContext testDbContext;
+
+    public SimpleUseIncludeBuilderTests()
     {
-        public TestDbContext testDbContext;
+        testDbContext = new TestDbContext();
+    }
 
-        public SimpleUseIncludeBuilderTests()
-        {
-            testDbContext = new TestDbContext();
-        }
+    public void Dispose()
+    {
+        testDbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
-        public void Dispose()
-        {
-            testDbContext.Dispose();
-            GC.SuppressFinalize(this);
-        }
+    [Fact]
+    public void NoIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void NoIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void NotEntityQueryProvider_ShouldNotThrow()
+    {
+        Func<IEnumerable<User>> getUsers = () => new List<User>()
+            .AsQueryable()
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Followers)
+            )
+            .Build()
+            .ToList();
 
-        [Fact]
-        public void NotEntityQueryProvider_ShouldNotThrow()
-        {
-            Func<IEnumerable<User>> getUsers = () => new List<User>()
-                .AsQueryable()
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Followers)
-                )
-                .Build()
-                .ToList();
+        getUsers.Should().NotThrow();
+        getUsers().Should().BeEmpty();
+    }
 
-            getUsers.Should().NotThrow();
-            getUsers().Should().BeEmpty();
-        }
+    [Fact]
+    public void SingleRootInclude_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog)
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void SingleRootInclude_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog)
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DifferentRootIncludes_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog)
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void DifferentRootIncludes_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog)
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .ToQueryString();
+        actualQuery.Should().NotBe(expectedQuery);
+    }
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
+    [Fact]
+    public void TwoRootIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog)
+            .Include(u => u.FollowingBlogs)
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void TwoRootIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog)
-                .Include(u => u.FollowingBlogs)
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+            .Include(u => u.FollowingBlogs)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                .Include(u => u.FollowingBlogs)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void TwoMixedIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog)
+            .Build()
+            .Include(u => u.FollowingBlogs)
+            .ToQueryString();
 
-        [Fact]
-        public void TwoMixedIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog)
-                .Build()
-                .Include(u => u.FollowingBlogs)
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+            .Include(u => u.FollowingBlogs)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                .Include(u => u.FollowingBlogs)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DifferentMixedIncludes_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Build()
+            .Include(u => u.FollowingBlogs)
+            .ToQueryString();
 
-        [Fact]
-        public void DifferentMixedIncludes_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Build()
-                .Include(u => u.FollowingBlogs)
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+            .Include(u => u.FollowingBlogs)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                .Include(u => u.FollowingBlogs)
-                .ToQueryString();
+        actualQuery.Should().NotBe(expectedQuery);
+    }
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
+    [Fact]
+    public void SingleFirstLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void SingleFirstLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts)
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void MultipleFirstLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts)
+                .Include(b => b.Followers)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void MultipleFirstLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts)
-                    .Include(b => b.Followers)
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DifferentFirstLevelIncludes_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts)
+                .Include(b => b.Followers)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void DifferentFirstLevelIncludes_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts)
-                    .Include(b => b.Followers)
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .ToQueryString();
+        actualQuery.Should().NotBe(expectedQuery);
+    }
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
-
-        [Fact]
-        public void MultiLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts, builder => builder
-                        .Include(p => p.Readers, builder => builder
-                            .Include(r => r.ReadHistory)
-                            .Include(r => r.Posts)
-                        )
-                        .Include(p => p.Author)
+    [Fact]
+    public void MultiLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts, builder => builder
+                    .Include(p => p.Readers, builder => builder
+                        .Include(r => r.ReadHistory)
+                        .Include(r => r.Posts)
                     )
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.OwnedBlog)
-                    )
+                    .Include(p => p.Author)
                 )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.ReadHistory)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Author)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.OwnedBlog)
-                .ToQueryString();
-
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void DifferentMultiLevelIncludes_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts, builder => builder
-                        .Include(p => p.Readers, builder => builder
-                            .Include(r => r.Posts)
-                        )
-                        .Include(p => p.Author)
-                    )
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.OwnedBlog)
-                    )
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.OwnedBlog)
                 )
-                .Build()
-                .ToQueryString();
+            )
+            .Build()
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.ReadHistory)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Readers)
-                            .ThenInclude(p => p.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                        .ThenInclude(p => p.Author)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.OwnedBlog)
-                .ToQueryString();
-
-            actualQuery.Should().NotBe(expectedQuery);
-        }
-
-        [Fact]
-        public void RootLevelExtensionIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Blogs
-                .UseIncludeBuilder()
-                .IncludeBlogChildren()
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Blogs
-                .Include(u => u.Posts)
-                .ToQueryString();
-
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void MultiLevelExtensionIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .IncludeBlogChildren()
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.FollowingBlogs, builder => builder
-                            .IncludeBlogChildren()
-                        )
-                    )
-                )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.FollowingBlogs)
-                            .ThenInclude(b => b.Posts)
-                .ToQueryString();
-
-            actualQuery.Should().Be(expectedQuery);
-        }
-
-        [Fact]
-        public void DifferentMultiLevelExtensionIncludes_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .IncludeBlogChildren()
-                    .Include(b => b.Followers, builder => builder
-                        .Include(f => f.OwnedBlog)
-                    )
-                )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                        .ThenInclude(f => f.OwnedBlog)
-                            .ThenInclude(b => b.Posts)
-                .ToQueryString();
-
-            actualQuery.Should().NotBe(expectedQuery);
-        }
-
-        [Fact]
-        public void IncludeChain_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog.Posts, builder => builder
-                    .Include(p => p.Readers)
-                )
-                .Build()
-                .ToQueryString();
-
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog.Posts)
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
                     .ThenInclude(p => p.Readers)
-                .ToQueryString();
+                        .ThenInclude(p => p.ReadHistory)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Author)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.OwnedBlog)
+            .ToQueryString();
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-        [Fact]
-        public void DifferentIncludeChain_ShouldNotMatch()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog.Posts, builder => builder
-                    .Include(p => p.Readers)
+    [Fact]
+    public void DifferentMultiLevelIncludes_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts, builder => builder
+                    .Include(p => p.Readers, builder => builder
+                        .Include(r => r.Posts)
+                    )
+                    .Include(p => p.Author)
                 )
-                .Build()
-                .ToQueryString();
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.OwnedBlog)
+                )
+            )
+            .Build()
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog.Posts)
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.ReadHistory)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Readers)
+                        .ThenInclude(p => p.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+                    .ThenInclude(p => p.Author)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.OwnedBlog)
+            .ToQueryString();
 
-            actualQuery.Should().NotBe(expectedQuery);
-        }
+        actualQuery.Should().NotBe(expectedQuery);
+    }
+
+    [Fact]
+    public void RootLevelExtensionIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Blogs
+            .UseIncludeBuilder()
+            .IncludeBlogChildren()
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Blogs
+            .Include(u => u.Posts)
+            .ToQueryString();
+
+        actualQuery.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public void MultiLevelExtensionIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .IncludeBlogChildren()
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.FollowingBlogs, builder => builder
+                        .IncludeBlogChildren()
+                    )
+                )
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.FollowingBlogs)
+                        .ThenInclude(b => b.Posts)
+            .ToQueryString();
+
+        actualQuery.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public void DifferentMultiLevelExtensionIncludes_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .IncludeBlogChildren()
+                .Include(b => b.Followers, builder => builder
+                    .Include(f => f.OwnedBlog)
+                )
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+                    .ThenInclude(f => f.OwnedBlog)
+                        .ThenInclude(b => b.Posts)
+            .ToQueryString();
+
+        actualQuery.Should().NotBe(expectedQuery);
+    }
+
+    [Fact]
+    public void IncludeChain_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog.Posts, builder => builder
+                .Include(p => p.Readers)
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog.Posts)
+                .ThenInclude(p => p.Readers)
+            .ToQueryString();
+
+        actualQuery.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public void DifferentIncludeChain_ShouldNotMatch()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog.Posts, builder => builder
+                .Include(p => p.Readers)
+            )
+            .Build()
+            .ToQueryString();
+
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog.Posts)
+            .ToQueryString();
+
+        actualQuery.Should().NotBe(expectedQuery);
     }
 }

--- a/tests/EFCore.IncludeBuilder.Tests/TestIncludeBuilderExtensions.cs
+++ b/tests/EFCore.IncludeBuilder.Tests/TestIncludeBuilderExtensions.cs
@@ -1,15 +1,14 @@
 ﻿using EFCore.IncludeBuilder.Builders.Interfaces;
 using EFCore.IncludeBuilder.Tests.Common.Models;
 
-namespace EFCore.IncludeBuilder.Tests
+namespace EFCore.IncludeBuilder.Tests;
+
+public static class TestIncludeBuilderExtensions
 {
-    public static class TestIncludeBuilderExtensions
+    public static TBuilder IncludeBlogChildren<TBase, TBuilder>(this IIncludeBuilder<TBase, Blog, TBuilder> blogBuilder)
+        where TBase : class
+        where TBuilder : IIncludeBuilder<TBase, Blog, TBuilder>
     {
-        public static TBuilder IncludeBlogChildren<TBase, TBuilder>(this IIncludeBuilder<TBase, Blog, TBuilder> blogBuilder)
-            where TBase : class
-            where TBuilder : IIncludeBuilder<TBase, Blog, TBuilder>
-            {
-                return blogBuilder.Include(b => b.Posts);
-            }
+        return blogBuilder.Include(b => b.Posts);
     }
 }

--- a/tests/EFCore.IncludeBuilder.Tests/UnintendedSyntaxTests.cs
+++ b/tests/EFCore.IncludeBuilder.Tests/UnintendedSyntaxTests.cs
@@ -6,147 +6,146 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace EFCore.IncludeBuilder.Tests
+namespace EFCore.IncludeBuilder.Tests;
+
+public class UnintendedSyntaxTests : IDisposable
 {
-    public class UnintendedSyntaxTests : IDisposable
+    public TestDbContext testDbContext;
+
+    public UnintendedSyntaxTests()
     {
-        public TestDbContext testDbContext;
+        testDbContext = new TestDbContext();
+    }
 
-        public UnintendedSyntaxTests()
-        {
-            testDbContext = new TestDbContext();
-        }
+    public void Dispose()
+    {
+        testDbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
-        public void Dispose()
-        {
-            testDbContext.Dispose();
-            GC.SuppressFinalize(this);
-        }
+    [Fact]
+    public void UseBuilderTwice_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog)
+            .Build()
+            .UseIncludeBuilder()
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void UseBuilderTwice_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog)
-                .Build()
-                .UseIncludeBuilder()
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DuplicateMultiLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts)
+                .Include(b => b.Posts)
+            )
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Followers)
+                .Include(b => b.Posts)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void DuplicateMultiLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts)
-                    .Include(b => b.Posts)
-                )
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Followers)
-                    .Include(b => b.Posts)
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void DuplicateFilteredMultiLevelIncludes_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(b => b.Posts)
+            )
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Followers)
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void DuplicateFilteredMultiLevelIncludes_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                    .Include(b => b.Posts)
-                )
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Followers)
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void UseTwoBuildersWithFilterAndWithoutFilter_ShouldMatchExpected()
+    {
+        var actualQuery = testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+                .Include(b => b.Posts)
+            )
+            .Build()
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Followers)
+                .Include(b => b.Posts)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void UseTwoBuildersWithFilterAndWithoutFilter_ShouldMatchExpected()
-        {
-            var actualQuery = testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                    .Include(b => b.Posts)
-                )
-                .Build()
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Followers)
-                    .Include(b => b.Posts)
-                )
-                .Build()
-                .ToQueryString();
+        var expectedQuery = testDbContext.Users
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Followers)
+            .Include(u => u.OwnedBlog)
+                .ThenInclude(b => b.Posts)
+            .ToQueryString();
 
-            var expectedQuery = testDbContext.Users
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Followers)
-                .Include(u => u.OwnedBlog)
-                    .ThenInclude(b => b.Posts)
-                .ToQueryString();
+        actualQuery.Should().Be(expectedQuery);
+    }
 
-            actualQuery.Should().Be(expectedQuery);
-        }
+    [Fact]
+    public void NavigationFixup_WarningThrown()
+    {
+        Action action = () => testDbContext.Users
+            .UseIncludeBuilder()
+            .Include(u => u.OwnedBlog, builder => builder
+                .Include(b => b.Posts)
+                .Include(b => b.Author)
+            )
+            .Build()
+            .ToQueryString();
 
-        [Fact]
-        public void NavigationFixup_WarningThrown()
-        {
-            var action = () => testDbContext.Users
-                .UseIncludeBuilder()
-                .Include(u => u.OwnedBlog, builder => builder
-                    .Include(b => b.Posts)
-                    .Include(b => b.Author)
-                )
-                .Build()
-                .ToQueryString();
-
-            action.Should().Throw<InvalidOperationException>()
-                .WithMessage("*'Microsoft.EntityFrameworkCore.Query.NavigationBaseIncludeIgnored'*");
-        }
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*'Microsoft.EntityFrameworkCore.Query.NavigationBaseIncludeIgnored'*");
     }
 }


### PR DESCRIPTION
- Added suggestion for file-scoped namespaces (Reason: less indentation).
  - Converted all files to file-scoped.
- Added suggestion for ```var``` when built-in or apparent type, explicit type otherwise (Reason: Following microsoft coding convetions)
  - Changed few places where ```var``` was used badly.  