### PR TITLE
Checking EFCore 7 Support

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        dotnet-version: ["6.0.x"]
+        dotnet-version: ["7.0.x"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EFCore.IncludeBuilder
 
-Extension library for Entity Framework Core that tries to improve upon the ```Include(...).ThenInclude(...)``` syntax in order to better support the following scenarios:
+Extension library for Entity Framework Core (6, 7) that tries to improve upon the ```Include(...).ThenInclude(...)``` syntax in order to better support the following scenarios:
 
 - Loading multiple entities on the same level (siblings).
 - Writing extension methods to include a whole set of entities at once.

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Benchmarks/Ainoraz.EFCore.IncludeBuilder.Benchmarks.csproj
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Benchmarks/Ainoraz.EFCore.IncludeBuilder.Benchmarks.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Tests/Ainoraz.EFCore.IncludeBuilder.Tests.csproj
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Tests/Ainoraz.EFCore.IncludeBuilder.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="FluentAssertions" Version="6.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,11 +3,11 @@
 
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<EFCoreVersion>6.0.7</EFCoreVersion>
+		<EFCoreVersion>7.0.1</EFCoreVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updated test dotnet and EFCore to 7.0, to check if `IncludeBuilder` is compatible. Found no issues.
- Updated other test dependencies.
- Added supported EFCore versions to readme.