### PR TITLE
Moved to central versioning.

### DIFF
--- a/Ainoraz.EFCore.IncludeBuilder.sln
+++ b/Ainoraz.EFCore.IncludeBuilder.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		tests\Directory.Build.props = tests\Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Global

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
+    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.7" />
+    <PackageVersion Include="Castle.Core" Version="5.1.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="MockQueryable.NSubstitute" Version="7.0.0" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/Ainoraz.EFCore.IncludeBuilder/Ainoraz.EFCore.IncludeBuilder.csproj
+++ b/src/Ainoraz.EFCore.IncludeBuilder/Ainoraz.EFCore.IncludeBuilder.csproj
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Package References">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Version="1.1.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Benchmarks/Ainoraz.EFCore.IncludeBuilder.Benchmarks.csproj
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Benchmarks/Ainoraz.EFCore.IncludeBuilder.Benchmarks.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+		<PackageReference Include="BenchmarkDotNet" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Tests.Common/Ainoraz.EFCore.IncludeBuilder.Tests.Common.csproj
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Tests.Common/Ainoraz.EFCore.IncludeBuilder.Tests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-		<PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-		<PackageReference Include="Castle.Core" Version="5.1.0" />
+		<PackageReference Include="AutoFixture.Xunit2" />
+		<PackageReference Include="MockQueryable.NSubstitute" />
+		<PackageReference Include="Castle.Core" />
 	</ItemGroup>
 </Project>

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Tests.Common/Customizations/IncludeCustomization.cs
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Tests.Common/Customizations/IncludeCustomization.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using AutoFixture;
-using AutoFixture.AutoMoq;
 
 namespace Ainoraz.EFCore.IncludeBuilder.Tests.Common.Customizations;
 
@@ -14,7 +13,5 @@ public class IncludeCustomization : ICustomization
             .ForEach(b => fixture.Behaviors.Remove(b));
 
         fixture.Behaviors.Add(new OmitOnRecursionBehavior(recursionDepth: 1));
-
-        fixture.Customize(new AutoMoqCustomization());
     }
 }

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Tests/Ainoraz.EFCore.IncludeBuilder.Tests.csproj
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Tests/Ainoraz.EFCore.IncludeBuilder.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.8.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.2.0">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Tests/FilteredUseIncludeBuilderTests.cs
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Tests/FilteredUseIncludeBuilderTests.cs
@@ -138,7 +138,7 @@ public class FilteredUseIncludeBuilderTests : IDisposable
             .UseIncludeBuilder()
             .Include(u => u.OwnedBlog, builder => builder
                 .Include(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
-                .Include(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
+                .Include(b => b.Followers.Where(b => b.ReadHistory.Count > 5))
             )
             .Build()
             .ToQueryString();
@@ -147,7 +147,7 @@ public class FilteredUseIncludeBuilderTests : IDisposable
             .Include(u => u.OwnedBlog)
                 .ThenInclude(b => b.Posts.Where(p => p.PostDate > DateTime.UtcNow.AddDays(-7)))
             .Include(u => u.OwnedBlog)
-                .ThenInclude(b => b.Followers.Where(b => b.ReadHistory.Count() > 5))
+                .ThenInclude(b => b.Followers.Where(b => b.ReadHistory.Count > 5))
             .ToQueryString();
 
         actualQuery.Should().Be(expectedQuery).And.NotBeEmpty();

--- a/tests/Ainoraz.EFCore.IncludeBuilder.Tests/IncludeBuilderTestabilityTests.cs
+++ b/tests/Ainoraz.EFCore.IncludeBuilder.Tests/IncludeBuilderTestabilityTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using MockQueryable.NSubstitute;
 using Xunit;
 using Ainoraz.EFCore.IncludeBuilder.Tests.Common.Customizations;
 using Ainoraz.EFCore.IncludeBuilder.Extensions;
@@ -32,9 +33,11 @@ public class IncludeBuilderTestabilityTests
 
     [Theory]
     [IncludeAutoData]
-    public void Queryable_ShouldNotThrow(IQueryable<User> users)
+    public void MockQueryable_ShouldNotThrow(IEnumerable<User> users)
     {
-        Action action = () => users
+        IQueryable<User> usersMockQueryable = users.BuildMock();
+
+        Action action = () => usersMockQueryable
             .UseIncludeBuilder()
             .Include(u => u.OwnedBlog, builder => builder
                 .Include(b => b.Posts)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,7 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.*" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.*" />
+		<!-- Testing against latest EntityFrameworkCore for breaking changes. -->
+		<PackageReference Include="Microsoft.EntityFrameworkCore" VersionOverride="7.0.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="7.0.*" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
- Moved to central versioning (ease of package updating and everything is in one place).
- Updated dependencies.
- Switched from `Moq` to `NSubstitute`.