### PR TITLE
Updating Deprecated Actions to Latest Ones

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -20,11 +20,12 @@ jobs:
         os: [ubuntu-latest]
         dotnet-version: ["8.0.206"]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup dotnet ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install deps
@@ -36,14 +37,14 @@ jobs:
       - name: Create package
         run: dotnet pack -c Release --no-build
       - name: Archive build artifacts for OS-${{ matrix.os }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-${{ matrix.os }}
           path: ./src/Ainoraz.EFCore.IncludeBuilder/bin/Release/
       - name: Benchmark
         run: dotnet run --project ./tests/Ainoraz.EFCore.IncludeBuilder.Benchmarks -c Release --no-build
       - name: Archive benchmarks for OS-${{ matrix.os }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarks-${{ matrix.os }}
           path: ./BenchmarkDotNet.Artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
         dotnet-version: ["8.0.206"]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup dotnet ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Set VERSION variable from tag


### PR DESCRIPTION
Github transitioned to Node 20, which has lead to some github action deprecations. Updating to latest action versions.